### PR TITLE
Add argument to automatically create missing dropdown labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ monday.items.create_item(board_id='12345678', group_id='today',  item_name='Do a
 
 **Available methods:**
 #### Items Resource (monday.items)
-- `create_item(board_id, group_id, item_name, column_values=None)` - Create an item on a board in the given group with name item_name.
+- `create_item(board_id, group_id, item_name, column_values=None, create_labels_if_missing=False)` - Create an item on a board in the given group with name item_name.
 
-- `create_subitem(parent_item_id, subitem_name, column_values=None)` - Create a subitem underneath a given parent item. Monday API will return an error if the board you're trying to add to does not have a subitems column/at least one subitem created.
+- `create_subitem(parent_item_id, subitem_name, column_values=None, create_labels_if_missing=False)` - Create a subitem underneath a given parent item. Monday API will return an error if the board you're trying to add to does not have a subitems column/at least one subitem created.
 
 - `fetch_items_by_column_value(board_id, column_id, value)` - Fetch items on a board by column value.
 

--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -5,7 +5,8 @@ from monday.utils import monday_json_stringify
 # Eventually I will organize this file better but you know what today is not that day.
 
 # ITEM RESOURCE QUERIES
-def mutate_item_query(board_id, group_id, item_name, column_values):
+def mutate_item_query(board_id, group_id, item_name, column_values,
+                      create_labels_if_missing):
     # Monday does not allow passing through non-JSON null values here,
     # so if you choose not to specify column values, need to set column_values to empty object.
     column_values = column_values if column_values else {}
@@ -16,16 +17,19 @@ def mutate_item_query(board_id, group_id, item_name, column_values):
             board_id: %s,
             group_id: %s,
             item_name: "%s",
-            column_values: %s
+            column_values: %s,
+            create_labels_if_missing: %s
         ) {
             id
         }
-    }''' % (board_id, group_id, item_name, monday_json_stringify(column_values))
+    }''' % (board_id, group_id, item_name, monday_json_stringify(column_values),
+            str(create_labels_if_missing).lower())
 
     return query
 
 
-def mutate_subitem_query(parent_item_id, subitem_name, column_values):
+def mutate_subitem_query(parent_item_id, subitem_name, column_values,
+                         create_labels_if_missing):
     column_values = column_values if column_values else {}
 
     return '''mutation
@@ -33,7 +37,8 @@ def mutate_subitem_query(parent_item_id, subitem_name, column_values):
         create_subitem (
             parent_item_id: %s,
             item_name: "%s",
-            column_values: %s
+            column_values: %s,
+            create_labels_if_missing: %s
         ) {
             id,
             name,
@@ -46,7 +51,8 @@ def mutate_subitem_query(parent_item_id, subitem_name, column_values):
                 name
             }
         }
-    }''' % (parent_item_id, subitem_name, monday_json_stringify(column_values))
+    }''' % (parent_item_id, subitem_name, monday_json_stringify(column_values),
+            str(create_labels_if_missing).lower())
 
 
 def get_item_query(board_id, column_id, value):

--- a/monday/resources/items.py
+++ b/monday/resources/items.py
@@ -9,12 +9,16 @@ class ItemResource(BaseResource):
     def __init__(self, token):
         super().__init__(token)
 
-    def create_item(self, board_id, group_id, item_name, column_values=None):
-        query = mutate_item_query(board_id, group_id, item_name, column_values)
+    def create_item(self, board_id, group_id, item_name, column_values=None,
+                    create_labels_if_missing=False):
+        query = mutate_item_query(board_id, group_id, item_name, column_values,
+                                  create_labels_if_missing)
         return json.loads(self.client.execute(query))
 
-    def create_subitem(self, parent_item_id, subitem_name, column_values=None):
-        query = mutate_subitem_query(parent_item_id, subitem_name, column_values)
+    def create_subitem(self, parent_item_id, subitem_name, column_values=None,
+                       create_labels_if_missing=False):
+        query = mutate_subitem_query(parent_item_id, subitem_name, column_values,
+                                     create_labels_if_missing)
         return json.loads(self.client.execute(query))
 
     def fetch_items_by_column_value(self, board_id, column_id, value):


### PR DESCRIPTION
Monday API raises a ColumnValueException if a nonexistent label is
provided for a dropdown column, while creating an item or a subitem.
This can be avoided by specifying `create_labels_if_missing=True`.
When specified, the missing labels will be created automatically.

This patch adds an optional boolean argumnet `create_labels_if_missing`
to `create_item` and `create_subitem` methods.
If not specified, it will assume `False` and will behave like it
currently does.
If `True` is specified, the missing dropdown labels will be created
automatically.