### PR TITLE
Fix parse error when the specified group id starts with a number

### DIFF
--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -14,7 +14,7 @@ def mutate_item_query(board_id, group_id, item_name, column_values):
     {
         create_item (
             board_id: %s,
-            group_id: %s,
+            group_id: "%s",
             item_name: "%s",
             column_values: %s
         ) {
@@ -375,7 +375,7 @@ def get_items_by_group_query(board_id, group_id):
     query = '''query
     {
         boards(ids: %s) {
-            groups(ids: %s) {
+            groups(ids: "%s") {
                 id
                 title
                 items {
@@ -404,7 +404,7 @@ def duplicate_group_query(board_id, group_id):
     query = '''
     mutation
     {
-        duplicate_group(board_id: %s, group_id: %s)
+        duplicate_group(board_id: %s, group_id: "%s")
         {
             id
         }
@@ -416,7 +416,7 @@ def archive_group_query(board_id, group_id):
     query = '''
     mutation
     {
-        archive_group(board_id: %s, group_id: %s)
+        archive_group(board_id: %s, group_id: "%s")
         {
             id
             archived
@@ -429,7 +429,7 @@ def delete_group_query(board_id, group_id):
     query = '''
     mutation
     {
-        delete_group(board_id: %s, group_id: %s)
+        delete_group(board_id: %s, group_id: "%s")
         {
             id
             deleted


### PR DESCRIPTION
A group id may start with a number. Monday API requires such id
to be quoted, otherwise it will return a Parse error.

This patch adds quotes around group_id parameters to avoid such
errors.