### PR TITLE
Add complexity resource

### DIFF
--- a/monday/client.py
+++ b/monday/client.py
@@ -7,7 +7,7 @@ monday.client
 """
 
 from .__version__ import __version__
-from .resources import ItemResource, UpdateResource, TagResource, BoardResource, UserResource, GroupResource
+from .resources import ItemResource, UpdateResource, TagResource, BoardResource, UserResource, GroupResource, ComplexityResource
 
 
 class MondayClient:
@@ -21,6 +21,7 @@ class MondayClient:
         self.boards = BoardResource(token=token)
         self.users = UserResource(token=token)
         self.groups = GroupResource(token=token)
+        self.complexity = ComplexityResource(token=token)
 
     def __str__(self):
         return f'MondayClient {__version__}'

--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -443,3 +443,16 @@ def delete_group_query(board_id, group_id):
         }
     }''' % (board_id, group_id)
     return query
+
+
+def get_complexity_query():
+    query = '''
+    query
+    {
+        complexity {
+            after,
+            reset_in_x_seconds
+        }
+    }'''
+
+    return query

--- a/monday/resources/__init__.py
+++ b/monday/resources/__init__.py
@@ -4,5 +4,6 @@ from .tags import TagResource
 from .boards import BoardResource
 from .users import UserResource
 from .groups import GroupResource
+from .complexity import ComplexityResource
 
-__all__ = ['ItemResource', 'UpdateResource', 'TagResource', 'BoardResource', 'UserResource', 'GroupResource']
+__all__ = ['ItemResource', 'UpdateResource', 'TagResource', 'BoardResource', 'UserResource', 'GroupResource', 'ComplexityResource']

--- a/monday/resources/complexity.py
+++ b/monday/resources/complexity.py
@@ -1,0 +1,11 @@
+from monday.resources.base import BaseResource
+from monday.query_joins import get_complexity_query
+
+
+class ComplexityResource(BaseResource):
+    def __init__(self, token):
+        super().__init__(token)
+
+    def get_complexity(self):
+        query = get_complexity_query()
+        return self.client.execute(query)


### PR DESCRIPTION
Monday.com API has a rate limit. Each operation has a complexity
cost, and an API token has a budget of complexity points that can
be spent per minute.
An operation fails if it costs more complexity points than the
complexity budget.
The complexity budget is reset every minute.

This patch adds the `ComplexityResource` with a method to retrieve
the remaining complexity budget, as well as the time in seconds
before the complexity budget is reset.