### PR TITLE
update fetch_items_by_id to include limit argument

### DIFF
--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -85,10 +85,12 @@ def get_item_query(board_id, column_id, value):
     return query
 
 
-def get_item_by_id_query(ids):
+def get_item_by_id_query(ids, limit):
     query = '''query
         {
-            items (ids: %s) {
+            items (ids: %s,
+                  limit %s
+            ) {
                 name,
                 group {
                     id
@@ -100,7 +102,7 @@ def get_item_by_id_query(ids):
                     value
                 }
             }
-        }''' % ids
+        }''' % (ids, limit)
 
     return query
 

--- a/monday/resources/items.py
+++ b/monday/resources/items.py
@@ -23,8 +23,8 @@ class ItemResource(BaseResource):
         query = get_item_query(board_id, column_id, value)
         return self.client.execute(query)
 
-    def fetch_items_by_id(self, ids):
-        query = get_item_by_id_query(ids)
+    def fetch_items_by_id(self, ids, limit=25):
+        query = get_item_by_id_query(ids, limit)
         return self.client.execute(query)
 
     def change_item_value(self, board_id, item_id, column_id, value):


### PR DESCRIPTION
The default is 25 which takes a long time when pulling from a board with many items. (In my testing the max is 100)