### PR TITLE
Feature/duplicate board query

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ monday.items.create_item(board_id='12345678', group_id='today',  item_name='Do a
 
 - `fetch_items_by_board_id([board_ids])` - Get all items on a board(s). Accepts a comma separated list of board ids.
 
+- `duplicate_board(board_id, duplicate_type)` - Duplicate a board by its id. It requires a duplication type to be chosen (*duplicate_board_with_structure / duplicate_board_with_pulses / duplicate_board_with_pulses_and_updates*).
+
 
 #### Users Resource (monday.users)
 - `fetch_users(**kwargs)` - Fetch user information associated with an account. See Monday API docs for a list of accepted keyword arguments.

--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -1,4 +1,5 @@
 import json
+from monday.resources.types import DuplicateTypes
 
 from monday.utils import monday_json_stringify
 
@@ -354,6 +355,22 @@ def get_columns_by_board_query(board_ids):
                  }
             }
         }''' % board_ids
+
+
+def duplicate_board_query(board_id: int, duplicate_type: DuplicateTypes):
+    query = """
+    mutation {
+        duplicate_board(board_id: %s, duplicate_type: %s) {
+            board {
+                id
+            }
+        }
+    }
+    """ % (
+        board_id,
+        duplicate_type.value,
+    )
+    return query
 
 
 # USER RESOURCE QUERIES

--- a/monday/resources/boards.py
+++ b/monday/resources/boards.py
@@ -1,6 +1,7 @@
 from monday.resources.base import BaseResource
-from monday.query_joins import get_boards_query, get_boards_by_id_query, get_board_items_query, \
+from monday.query_joins import duplicate_board_query, get_boards_query, get_boards_by_id_query, get_board_items_query, \
     get_columns_by_board_query
+from monday.resources.types import DuplicateTypes
 
 
 class BoardResource(BaseResource):
@@ -21,4 +22,8 @@ class BoardResource(BaseResource):
 
     def fetch_columns_by_board_id(self, board_ids):
         query = get_columns_by_board_query(board_ids)
+        return self.client.execute(query)
+
+    def duplicate_board(self, board_id: int, duplicate_type: DuplicateTypes):
+        query = duplicate_board_query(board_id, duplicate_type)
         return self.client.execute(query)

--- a/monday/resources/types.py
+++ b/monday/resources/types.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class DuplicateTypes(Enum):
+    """Board duplication types"""
+
+    WITH_STRUCTURE = "duplicate_board_with_structure"
+    WITH_PULSES = "duplicate_board_with_pulses"
+    WITH_PULSES_AND_UPDATES = "duplicate_board_with_pulses_and_updates"

--- a/monday/tests/test_board_resource.py
+++ b/monday/tests/test_board_resource.py
@@ -1,5 +1,5 @@
 from monday.tests.test_case_resource import BaseTestCase
-from monday.query_joins import get_boards_query, get_boards_by_id_query, get_board_items_query, \
+from monday.query_joins import duplicate_board_query, get_boards_query, get_boards_by_id_query, get_board_items_query, \
     get_columns_by_board_query
 
 
@@ -22,3 +22,9 @@ class BoardTestCase(BaseTestCase):
     def test_get_columns_by_board_query(self):
         query = get_columns_by_board_query(board_ids=self.board_id)
         self.assertIn(str(self.board_id), query)
+
+    def test_duplicate_board_query(self):
+        query = duplicate_board_query(board_id=self.board_id, duplicate_type=self.duplicate_type)
+        self.assertIn(str(self.board_id), query)
+        self.assertNotIn(str(self.duplicate_type), query)
+        self.assertIn(str(self.duplicate_type.value), query)

--- a/monday/tests/test_case_resource.py
+++ b/monday/tests/test_case_resource.py
@@ -1,5 +1,7 @@
 import unittest
 
+from monday.resources.types import DuplicateTypes
+
 
 class BaseTestCase(unittest.TestCase):
 
@@ -9,6 +11,7 @@ class BaseTestCase(unittest.TestCase):
         self.item_id = 24
         self.board_id = 12
         self.board_kind = "public"
+        self.duplicate_type = DuplicateTypes.WITH_PULSES
         self.group_id = 7
         self.column_id = "file_column"
         self.user_ids = [1287123, 1230919]


### PR DESCRIPTION
**What changed:**
Added duplicate_board() function and a test for it.
A _types.py_ file has been included where type hints can be set up. In this case it stores the required duplication types (_duplicate_board_with_structure / duplicate_board_with_pulses / duplicate_board_with_pulses_and_updates_)
Also, Readme has been updated.

**What resolves**
Issue #46 - Will allow users to duplicate boards easily.