### PR TITLE
Add id to payload of get_item_by_id_query

### DIFF
--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -89,6 +89,7 @@ def get_item_by_id_query(ids):
     query = '''query
         {
             items (ids: %s) {
+                id,
                 name,
                 group {
                     id


### PR DESCRIPTION
Add id to payload of get_item_by_id_query. 

It's nice to have consistent return objects. I had some code for retrieving items from a board, wanted to reuse it with the other query for a list of ids, and couldn't before this change.

Also it seems potentially incorrect to not ask for the ID: when asking for more than one id, we might want the IDs of returned objects, and without asking for them we have to assume come in the same order - I don't know whether they do or don't, but adding the ids back to the payload seemed like a worse solution than asking for them back.