### PR TITLE
Added mutation for multiple items

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -31,7 +31,10 @@ Getting started
 
    monday.items.create_item(board_id='12345678', group_id='today',  item_name='Do a thing')
 
-**Available methods:** #### Items Resource (monday.items) -
+**Available methods:** 
+
+Items Resource (monday.items) 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ``create_item(board_id, group_id, item_name, column_values=None, create_labels_if_missing=False)``
 - Create an item on a board in the given group with name item_name.
 

--- a/monday/resources/items.py
+++ b/monday/resources/items.py
@@ -1,7 +1,7 @@
 from monday.resources.base import BaseResource
 from monday.query_joins import mutate_item_query, get_item_query, update_item_query, get_item_by_id_query, \
     update_multiple_column_values_query, mutate_subitem_query, add_file_to_column_query, delete_item_query, \
-    archive_item_query, move_item_to_group_query
+    archive_item_query, move_item_to_group_query, mutate_multiple_items_query
 
 
 class ItemResource(BaseResource):
@@ -18,6 +18,10 @@ class ItemResource(BaseResource):
                        create_labels_if_missing=False):
         query = mutate_subitem_query(parent_item_id, subitem_name, column_values,
                                      create_labels_if_missing)
+        return self.client.execute(query)
+
+    def mutate_multiple_items(self, items_data):
+        query = mutate_multiple_items_query(items_data)
         return self.client.execute(query)
 
     def fetch_items_by_column_value(self, board_id, column_id, value):
@@ -48,7 +52,7 @@ class ItemResource(BaseResource):
     def archive_item_by_id(self, item_id):
         query = archive_item_query(item_id)
         return self.client.execute(query)
-    
+
     def delete_item_by_id(self, item_id):
         query = delete_item_query(item_id)
         return self.client.execute(query)


### PR DESCRIPTION
Added a function which allows to modify multiple items at once using graphQL's mutation query. 
The function takes a list of dictionaries with methods and any additional parameters the method requires. 

This already saved me hours when working with large sets of data, as the only way to work with multiple items with this library was to call the update/create functions one by one, whereas now you're able to perform multiple operations at once.

Hope you find it as much of a lifesaver too!


```
items_data = [
    {
        "method": "create_item",
        "board_id": 1437462152,
        "group_id": "new_group",
        "item_name": "New Item",
        "column_values": {"status": "done"},
        "create_labels_if_missing": True
    },
    {
        "method": "change_multiple_column_values",
        "board_id": 1435323152,
        "item_id": 1345543264,
        "column_values": {"status": "done"},
        "create_labels_if_missing": True
    }
]

response = monday.items.mutate_multiple_items(items_data)
```