### PR TITLE
Get workspaces query

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -31,7 +31,10 @@ Getting started
 
    monday.items.create_item(board_id='12345678', group_id='today',  item_name='Do a thing')
 
-**Available methods:** #### Items Resource (monday.items) -
+**Available methods:** 
+
+Items Resource (monday.items) 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ``create_item(board_id, group_id, item_name, column_values=None, create_labels_if_missing=False)``
 - Create an item on a board in the given group with name item_name.
 

--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -531,18 +531,15 @@ def get_complexity_query():
 def get_workspaces_query():
     query = '''
     query {
-        boards {
-            workspace {
+            workspaces {
                 id
                 name
                 kind
                 description
             }
-        }
     }
     '''
     return query
-
 
 def create_workspace_query(name, kind, description=""):
     query = '''


### PR DESCRIPTION
Fixed an incorrectly working get_workspaces query, which was returning more workspaces than actually exist, as well as sometimes was returning "None" workspaces. Updated the query, now works as expected.