### PR TITLE
Extend get_boards_* to include workspace info, provide fetch_boards_by_workspace_id() function.

### DIFF
--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -350,6 +350,10 @@ def get_boards_query(limit: int = None, page: int = None, ids: List[int] = None,
                 title
                 type
             }
+            workspace{
+                name
+                id
+            }
         }
     }''' % ', '.join(query_params)
 
@@ -376,6 +380,10 @@ def get_boards_by_id_query(board_ids):
                 title
                 type
                 settings_str
+            }
+            workspace{
+                name
+                id
             }
         }
     }''' % board_ids

--- a/monday/resources/boards.py
+++ b/monday/resources/boards.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+import copy
+from typing import List, Optional, Required
 from monday.resources.base import BaseResource
 from monday.query_joins import (
     get_boards_query,
@@ -14,7 +15,15 @@ class BoardResource(BaseResource):
     def __init__(self, token):
         super().__init__(token)
 
-    def fetch_boards(self, limit: int = None, page: int = None, ids: List[int] = None, board_kind: BoardKind = None, state: BoardState = None, order_by: BoardsOrderBy = None):
+    def fetch_boards(
+        self,
+        limit: int = None,
+        page: int = None,
+        ids: List[int] = None,
+        board_kind: BoardKind = None,
+        state: BoardState = None,
+        order_by: BoardsOrderBy = None,
+    ):
         query = get_boards_query(limit, page, ids, board_kind, state, order_by)
         return self.client.execute(query)
 
@@ -22,7 +31,31 @@ class BoardResource(BaseResource):
         query = get_boards_by_id_query(board_ids)
         return self.client.execute(query)
 
-    def fetch_items_by_board_id(self, board_ids, limit: Optional[int]=None, page: Optional[int]=None):
+    def fetch_boards_by_workspace_id(
+        self,
+        limit: int = 1000,
+        workspace_id: Required[int] = None,
+        page: int = None,
+        ids: List[int] = None,
+        board_kind: BoardKind = None,
+        state: BoardState = None,
+        order_by: BoardsOrderBy = None,
+    ):
+        query = get_boards_query(limit, page, ids, board_kind, state, order_by)
+        response = self.client.execute(query)
+        filtered_boards = copy.deepcopy(response)
+        filtered_boards["data"]["boards"].clear()
+        for board in response["data"]["boards"]:
+            try:
+                if board["workspace"]["id"] == workspace_id:
+                    filtered_boards["data"]["boards"].append(board)
+            except TypeError:
+                continue
+        return filtered_boards
+
+    def fetch_items_by_board_id(
+        self, board_ids, limit: Optional[int] = None, page: Optional[int] = None
+    ):
         query = get_board_items_query(board_ids, limit=limit, page=page)
         return self.client.execute(query)
 
@@ -30,6 +63,8 @@ class BoardResource(BaseResource):
         query = get_columns_by_board_query(board_ids)
         return self.client.execute(query)
 
-    def create_board(self, board_name: str, board_kind: BoardKind, workspace_id: int = None):
+    def create_board(
+        self, board_name: str, board_kind: BoardKind, workspace_id: int = None
+    ):
         query = create_board_by_workspace_query(board_name, board_kind, workspace_id)
         return self.client.execute(query)


### PR DESCRIPTION
Update the response for the following queries to include Workspace information.

```
get_boards_query()
get_boards_by_id_query()
```

Further, extend the `boards` resource to allow for fetching a list of boards by workspace_id.
Add:
```
fetch_boards_by_workspace_id()
```
