### PR TITLE
Empty parens are no longer supported

### DIFF
--- a/monday/__version__.py
+++ b/monday/__version__.py
@@ -1,3 +1,3 @@
-__version__ = '2.0.0-pre'
+__version__ = '2.0.0rc1'
 __author__ = 'Christina D\'Astolfo'
 __email__ = 'chdastolfo@gmail.com, lemi@prodperfect.com, pevner@prodperfect.com'

--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -357,13 +357,13 @@ def get_tags_query(tags):
 def get_board_items_query(board_id: Union[str, int], limit: Optional[int] = None, page: Optional[int] = None) -> str:
     raw_params = locals().items()
     item_params = gather_params(raw_params, exclusion_list=["board_id", "item_ids"])
-    joined_params = ', '.join(item_params)
+    joined_params = f"({', '.join(item_params)})" if item_params else ""
 
     query = '''query{
         boards(ids: %s){
             name
-            items_page (){
-                items(%s) {
+            items_page {
+                items %s {
                     group {
                         id
                         title
@@ -393,12 +393,12 @@ def get_boards_query(limit: int = None, page: int = None, ids: List[int] = None,
             value = v
             if isinstance(v, Enum):
                 value = v.value
-
             query_params.append("%s: %s" % (k, value))
+    joined_params = f"({', '.join(query_params)})" if query_params else ""
 
     query = '''query
     {
-        boards (%s) {
+        boards %s {
             id
             name
             permissions
@@ -416,7 +416,7 @@ def get_boards_query(limit: int = None, page: int = None, ids: List[int] = None,
                 type
             }
         }
-    }''' % ', '.join(query_params)
+    }''' % joined_params
 
     return query
 
@@ -486,9 +486,10 @@ def create_board_by_workspace_query(board_name: str, board_kind: BoardKind, work
 
 # USER RESOURCE QUERIES
 def get_users_query(**kwargs):
+    joined_params = f"({', '.join(['%s: %s' % (arg, kwargs.get(arg)) for arg in kwargs])})" if kwargs else ""
     query = '''query
     {
-        users (%s) {
+        users %s {
             id
             name
             email
@@ -498,7 +499,7 @@ def get_users_query(**kwargs):
               name
             }
         }
-    }''' % ', '.join(["%s: %s" % (arg, kwargs.get(arg)) for arg in kwargs])
+    }''' % joined_params
     return query
 
 

--- a/monday/tests/test_board_resource.py
+++ b/monday/tests/test_board_resource.py
@@ -38,14 +38,14 @@ class BoardTestCase(BaseTestCase):
     def test_get_board_items_query(self):
         query = get_board_items_query(board_id=self.board_id)
         self.assertIn(str(self.board_id), query)
-        items_line = 'items()'
+        items_line = 'items'
         self.assertIn(items_line, query)
 
     def test_get_board_items_query_with_limit_and_pages(self):
         limit = 100
         page = 1
         query = get_board_items_query(board_id=self.board_id, limit=limit, page=page)
-        items_line = f'items(limit: {limit}, page: {page})'
+        items_line = f'items (limit: {limit}, page: {page})'
         self.assertIn(items_line, query)
 
     def test_get_columns_by_board_query(self):


### PR DESCRIPTION
See https://developer.monday.com/api-reference/changelog/empty-parentheses-no-longer-supported for details.  The previous release definitely is broken.  This should fix that.

Also, moving to the official python versioning scheme, rather than nearly-universally-accepted semantic versioning.