### PR TITLE
Fixed an error when duplicating boards.

### DIFF
--- a/monday/__version__.py
+++ b/monday/__version__.py
@@ -1,3 +1,3 @@
-__version__ = '2.0.0rc3'
+__version__ = '2.0.1'
 __author__ = 'Christina D\'Astolfo'
 __email__ = 'chdastolfo@gmail.com, lemi@prodperfect.com, pevner@prodperfect.com'

--- a/monday/resources/boards.py
+++ b/monday/resources/boards.py
@@ -33,5 +33,5 @@ class BoardResource(BaseResource):
     def duplicate_board(self, board_id: int, duplicate_type: DuplicateType, board_name: Optional[str] = None,
                         folder_id: Optional[int] = None, keep_subscribers: Optional[bool] = None,
                         workspace_id: Optional[int] = None):
-        query = duplicate_board_query(board_id, duplicate_type, board_name, workspace_id, folder_id, keep_subscribers)
+        query = duplicate_board_query(board_id, duplicate_type, board_name, folder_id, keep_subscribers, workspace_id)
         return self.client.execute(query)


### PR DESCRIPTION
The parameters were passed to the `duplicate_board_query` in the wrong order, that called an error. The other part that might be confusing is that in `duplicate_board_query` if you pass `True` as  `keep_board_subscribers` parameter it will return an error since it expects JSON data so instead of passing `True` you will have to pass `'true'` as a string and lowercase.