### PR TITLE
Fixed error ModuleNotFoundError: No module named 'requests' when installing

### DIFF
--- a/monday/__init__.py
+++ b/monday/__init__.py
@@ -1,4 +1,4 @@
-from .__version__ import __author__, __email__, __version__
+from setup import __author__, __email__, __version__
 
 from .client import MondayClient
 

--- a/monday/__init__.py
+++ b/monday/__init__.py
@@ -1,4 +1,4 @@
-from setup import __author__, __email__, __version__
+from ..setup import __author__, __email__, __version__
 
 from .client import MondayClient
 

--- a/monday/__version__.py
+++ b/monday/__version__.py
@@ -1,3 +1,0 @@
-__version__ = '2.0.0rc3'
-__author__ = 'Christina D\'Astolfo'
-__email__ = 'chdastolfo@gmail.com, lemi@prodperfect.com, pevner@prodperfect.com'

--- a/monday/client.py
+++ b/monday/client.py
@@ -6,7 +6,7 @@ monday.client
 :license: Apache2, see LICENSE for more details.
 """
 
-from .__version__ import __version__
+from ..setup import __version__
 from .resources import CustomResource, ItemResource, ColumnsResource, UpdateResource, TagResource, BoardResource, \
     UserResource, GroupResource, ComplexityResource, WorkspaceResource, NotificationResource, MeResource
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 from setuptools import setup
 
-from monday import __author__, __email__, __version__
+__version__ = '2.0.0rc3'
+__author__ = 'Christina D\'Astolfo'
+__email__ = 'chdastolfo@gmail.com, lemi@prodperfect.com, pevner@prodperfect.com'
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -19,6 +21,9 @@ setup(name='monday',
       zip_safe=False,
       license='BSD',
       python_requires='>=3.6',
+      install_requires=[
+          'requests'
+      ],
       classifiers=[
           "Programming Language :: Python :: 3",
           "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
So when you install monday without requests installed you get a `ModuleNotFoundError: No module named 'requests'`
when trying to run anything from the monday library since GraphQLClient depends on it. This was caused due to requests not specified in install_requires in setup.py file and due to monday being imported in the setup.py file before running the setup. I fixed it by moving everything from the version.py file to setup.py file.

