### PR TITLE
Add requests timeout

### DIFF
--- a/monday/client.py
+++ b/monday/client.py
@@ -14,9 +14,10 @@ _DEFAULT_HEADERS = {
     "API-Version": "2023-10"
 }
 
+DEFAULT_TIMEOUT = 60
 
 class MondayClient:
-    def __init__(self, token, headers=None):
+    def __init__(self, token, headers=None, timeout=DEFAULT_TIMEOUT):
         """
         :param token: API token for the new :class:`BaseResource` object.
         :param headers: (optional) headers for the new :class:`BaseResource` object.
@@ -25,18 +26,18 @@ class MondayClient:
         if not headers:
             headers = _DEFAULT_HEADERS.copy()
 
-        self.custom = CustomResource(token=token, headers=headers)
-        self.items = ItemResource(token=token, headers=headers)
-        self.columns = ColumnsResource(token=token, headers=headers)
-        self.updates = UpdateResource(token=token, headers=headers)
-        self.tags = TagResource(token=token, headers=headers)
-        self.boards = BoardResource(token=token, headers=headers)
-        self.users = UserResource(token=token, headers=headers)
-        self.groups = GroupResource(token=token, headers=headers)
-        self.complexity = ComplexityResource(token=token, headers=headers)
-        self.workspaces = WorkspaceResource(token=token, headers=headers)
-        self.notifications = NotificationResource(token=token, headers=headers)
-        self.me = MeResource(token=token, headers=headers)
+        self.custom = CustomResource(token=token, headers=headers, timeout=timeout)
+        self.items = ItemResource(token=token, headers=headers, timeout=timeout)
+        self.columns = ColumnsResource(token=token, headers=headers, timeout=timeout)
+        self.updates = UpdateResource(token=token, headers=headers, timeout=timeout)
+        self.tags = TagResource(token=token, headers=headers, timeout=timeout)
+        self.boards = BoardResource(token=token, headers=headers, timeout=timeout)
+        self.users = UserResource(token=token, headers=headers, timeout=timeout)
+        self.groups = GroupResource(token=token, headers=headers, timeout=timeout)
+        self.complexity = ComplexityResource(token=token, headers=headers, timeout=timeout)
+        self.workspaces = WorkspaceResource(token=token, headers=headers, timeout=timeout)
+        self.notifications = NotificationResource(token=token, headers=headers, timeout=timeout)
+        self.me = MeResource(token=token, headers=headers, timeout=timeout)
 
     def __str__(self):
         return f'MondayClient {__version__}'

--- a/monday/graphqlclient/client.py
+++ b/monday/graphqlclient/client.py
@@ -6,10 +6,12 @@ from monday.exceptions import MondayQueryError
 
 TOKEN_HEADER = 'Authorization'
 
+DEFAULT_TIMEOUT = 60
 
 class GraphQLClient:
-    def __init__(self, endpoint):
+    def __init__(self, endpoint, timeout=DEFAULT_TIMEOUT):
         self.endpoint = endpoint
+        self.timeout = timeout
         self.token = None
         self.headers = {}
 
@@ -43,7 +45,7 @@ class GraphQLClient:
             ]
 
         try:
-            response = requests.request("POST", self.endpoint, headers=headers, data=payload, files=files)
+            response = requests.request("POST", self.endpoint, headers=headers, data=payload, files=files, timeout=self.timeout)
             response.raise_for_status()
             response_data = response.json()
             self._throw_on_error(response_data)

--- a/monday/resources/base.py
+++ b/monday/resources/base.py
@@ -7,10 +7,10 @@ _URLS = {
 
 
 class BaseResource:
-    def __init__(self, token, headers):
+    def __init__(self, token, headers, timeout):
         self._token = token
-        self.client = GraphQLClient(_URLS['prod'])
-        self.file_upload_client = GraphQLClient(_URLS['file'])
+        self.client = GraphQLClient(_URLS['prod'], timeout=timeout)
+        self.file_upload_client = GraphQLClient(_URLS['file'], timeout=timeout)
         self.client.inject_token(token)
         self.client.inject_headers(headers)
         self.file_upload_client.inject_token(token)


### PR DESCRIPTION
The Python `requests` library does not set timeouts by default.
Without an explicit timeout, requests can potentially hang indefinitely.

This is also documented:
> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely
https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts