### PR TITLE
Allow fetch_items_by_column_value to accept List as value argument

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -31,7 +31,7 @@ Getting started
 
    monday.items.create_item(board_id='12345678', group_id='today',  item_name='Do a thing')
 
-**Available methods:** 
+**Available methods:**
 
 Items Resource (monday.items)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -46,7 +46,7 @@ Items Resource (monday.items)
    subitems column/at least one subitem created.
 
 -  ``fetch_items_by_column_value(board_id, column_id, value)`` - Fetch
-   items on a board by column value.
+   items on a board by column value. The value argument accepts a list.
 
 -  ``fetch_items_by_id(board_id, [ids])`` - Fetch items from any board
    by ids, passed in as an array of integers.

--- a/docs/_build/html/README.html
+++ b/docs/_build/html/README.html
@@ -15,22 +15,22 @@
     <link rel="index" title="Index" href="genindex.html" />
     <link rel="search" title="Search" href="search.html" />
     <link rel="prev" title="Welcome to monday’s documentation!" href="index.html" />
-   
+
   <link rel="stylesheet" href="_static/custom.css" type="text/css" />
-  
-  
+
+
   <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
 
   </head><body>
-  
+
 
     <div class="document">
       <div class="documentwrapper">
         <div class="bodywrapper">
-          
+
 
           <div class="body" role="main">
-            
+
   <section id="monday">
 <h1>monday<a class="headerlink" href="#monday" title="Permalink to this heading">¶</a></h1>
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section --><p><a class="reference external" href="#contributors-"><img alt="All Contributors" src="https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square" /></a> A monday.com Python Client Library</p>
@@ -63,7 +63,7 @@ here</a>.</p>
 return an error if the board you’re trying to add to does not have a
 subitems column/at least one subitem created.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">fetch_items_by_column_value(board_id,</span> <span class="pre">column_id,</span> <span class="pre">value)</span></code> - Fetch
-items on a board by column value.</p></li>
+items on a board by column value. The value argument accepts a list.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">fetch_items_by_id(board_id,</span> <span class="pre">[ids])</span></code> - Fetch items from any board
 by ids, passed in as an array of integers.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">change_item_value(board_id,</span> <span class="pre">item_id,</span> <span class="pre">column_id,</span> <span class="pre">value)</span></code> - Change
@@ -215,7 +215,7 @@ board</a></p></li>
 
 
           </div>
-          
+
         </div>
       </div>
       <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
@@ -284,18 +284,18 @@ board</a></p></li>
     </div>
     <div class="footer">
       &copy;2023, Christina D'Astolfo, Lemi Boyce.
-      
+
       |
       Powered by <a href="http://sphinx-doc.org/">Sphinx 6.1.1</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
-      
+
       |
       <a href="_sources/README.rst.txt"
           rel="nofollow">Page source</a>
     </div>
 
-    
 
-    
+
+
   </body>
 </html>

--- a/docs/_build/html/_sources/README.rst.txt
+++ b/docs/_build/html/_sources/README.rst.txt
@@ -41,7 +41,7 @@ Getting started
    subitems column/at least one subitem created.
 
 -  ``fetch_items_by_column_value(board_id, column_id, value)`` - Fetch
-   items on a board by column value.
+   items on a board by column value. The value argument accepts a list.
 
 -  ``fetch_items_by_id(board_id, [ids])`` - Fetch items from any board
    by ids, passed in as an array of integers.

--- a/monday/__version__.py
+++ b/monday/__version__.py
@@ -1,3 +1,3 @@
-__version__ = '2.0.1'
-__author__ = 'Christina D\'Astolfo'
-__email__ = 'chdastolfo@gmail.com, lemi@prodperfect.com, pevner@prodperfect.com'
+__version__ = "2.0.2"
+__author__ = "Christina D'Astolfo"
+__email__ = "chdastolfo@gmail.com, lemi@prodperfect.com, pevner@prodperfect.com"

--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -59,7 +59,10 @@ def mutate_subitem_query(parent_item_id, subitem_name, column_values,
 
 
 def get_item_query(board_id, column_id, value, limit=None, cursor=None):
-    columns = [{"column_id": str(column_id), "column_values": [str(value)]}] if not cursor else None
+    if not isinstance(value, list):
+        value = [value]
+
+    columns = [{"column_id": str(column_id), "column_values": [str(v) for v in value]}] if not cursor else None
 
     raw_params = locals().items()
     items_page_params = gather_params(raw_params, excluded_params=["column_id", "value"])
@@ -83,7 +86,7 @@ def get_item_query(board_id, column_id, value, limit=None, cursor=None):
                         id
                         text
                         value
-                    }                
+                    }
                 }
             }
         }''' % items_page_params
@@ -286,7 +289,7 @@ def delete_update_query(item_id):
 
 
 def get_updates_for_item_query(item, limit):
-    query = '''query{                
+    query = '''query{
         items(ids: %s){
             updates (limit: %s) {
                 id,
@@ -706,34 +709,34 @@ def get_me_query():
         account {
             id
         },
-        birthday,   
-        country_code,   
-        created_at, 
-        join_date,  
-        email,  
+        birthday,
+        country_code,
+        created_at,
+        join_date,
+        email,
         enabled,
-        id, 
-        is_admin,   
-        is_guest,   
-        is_pending, 
-        is_view_only,   
-        location,   
-        mobile_phone,   
-        name,   
-        phone,  
-        photo_original, 
+        id,
+        is_admin,
+        is_guest,
+        is_pending,
+        is_view_only,
+        location,
+        mobile_phone,
+        name,
+        phone,
+        photo_original,
         photo_small,
         photo_thumb,
-        photo_thumb_small,  
-        photo_tiny, 
+        photo_thumb_small,
+        photo_tiny,
         teams {
             id,
             name
-        },  
-        time_zone_identifier,   
-        title,  
+        },
+        time_zone_identifier,
+        title,
         url,
-        utc_hours_diff, 
+        utc_hours_diff,
         }
     }"""
     return query

--- a/monday/tests/test_item_resource.py
+++ b/monday/tests/test_item_resource.py
@@ -25,6 +25,15 @@ class ItemTestCase(BaseTestCase):
         self.assertIn(self.column_id, query)
         self.assertIn("foo", query)
 
+    def test_get_item_query_as_list(self):
+        query = get_item_query(
+            board_id=self.board_id, column_id=self.column_id, value=["foo", "bar"]
+        )
+        self.assertIn(str(self.board_id), query)
+        self.assertIn(self.column_id, query)
+        self.assertIn('"foo"', query)
+        self.assertIn('"bar"', query)
+
     def test_get_item_query_with_limit_and_cursor(self):
         limit = 10
         cursor = "MSw0NTc5ODYzMTkyLFRWX2ljOW..."
@@ -78,7 +87,7 @@ class ItemTestCase(BaseTestCase):
                 id
             }
         }'''.replace(" ", ""), query.replace(" ", ""))
-        
+
     def test_archive_item_by_id(self):
         query = archive_item_query(item_id=self.item_id)
         self.assertIn(str(self.item_id), query)


### PR DESCRIPTION
Allow the `fetch_items_by_column_value()` method to accept a List as the `value` argument. This would allow fetching multiple items at the same time, in a single API call.

For backwards compatibility the `value` argument continues to accept a single string value as well.

Updated Unit Tests and automatically removed some trailing whitespaces.

Testing:
```
>>> data = monday.items.fetch_items_by_column_value(board_id, "text", "1111")
>>> for d in data['data']['items_page_by_column_values']['items']:
...     print(d['id'])
...     
First Item

>>> data = monday.items.fetch_items_by_column_value(board_id, "text", ["1111", "2222"])
>>> for d in data['data']['items_page_by_column_values']['items']:
...     print(d['id'])
... 
First Item
Second Item
```
