### PR TITLE
Fix get workspaces query

### DIFF
--- a/monday/query_joins.py
+++ b/monday/query_joins.py
@@ -618,13 +618,11 @@ def get_complexity_query():
 def get_workspaces_query():
     query = '''
     query {
-        boards {
-            workspace {
-                id
-                name
-                kind
-                description
-            }
+        workspaces {
+            id
+            name
+            kind
+            description
         }
     }
     '''

--- a/monday/tests/test_case_resource.py
+++ b/monday/tests/test_case_resource.py
@@ -29,4 +29,3 @@ class BaseTestCase(unittest.TestCase):
         self.team_ids = [105939, 105940, 105941]
         self.notification_text = "This is an awesome notification."
         self.notification_target_type = "Project"
-    

--- a/monday/tests/test_workspace_resource.py
+++ b/monday/tests/test_workspace_resource.py
@@ -12,13 +12,11 @@ class WorkspaceTestCase(BaseTestCase):
         query = get_workspaces_query()
         self.assertEqual('''
         query {
-            boards {
-                workspace {
-                    id
-                    name
-                    kind
-                    description
-                }
+            workspaces {
+                id
+                name
+                kind
+                description
             }
         }
         '''.replace(" ", ""), query.replace(" ", ""))
@@ -33,7 +31,7 @@ class WorkspaceTestCase(BaseTestCase):
         self.assertIn(str(self.workspace_id), query)
         self.assertIn(str(self.user_ids), query)
         self.assertIn(str(self.workspace_user_kind), query)
-    
+
     def test_delete_users_from_workspace_query(self):
         query = delete_users_from_workspace_query(self.workspace_id, self.user_ids)
         self.assertIn(str(self.workspace_id), query)
@@ -43,11 +41,8 @@ class WorkspaceTestCase(BaseTestCase):
         query = add_teams_to_workspace_query(self.workspace_id, self.team_ids)
         self.assertIn(str(self.workspace_id), query)
         self.assertIn(str(self.team_ids), query)
-    
+
     def test_delete_teams_from_workspace_query(self):
         query = delete_teams_from_workspace_query(self.workspace_id, self.team_ids)
         self.assertIn(str(self.workspace_id), query)
         self.assertIn(str(self.team_ids), query)
-    
-
-        


### PR DESCRIPTION
Fix an incorrectly working `get_workspaces` query, which was returning more workspaces than actually exist, as well as sometimes was returning `None` workspaces. Updated the query, now works as expected.

Courtesy of @olegkron via PR #107 and @nickmoreton via PR #122.